### PR TITLE
Add diorite platform support for Pebble 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
         "sdkVersion": "3",
         "targetPlatforms": [
             "aplite",
-            "basalt"
+            "basalt",
+            "diorite"
         ],
         "uuid": "8d71cefa-a394-4376-a157-399bff1045e6",
         "watchapp": {


### PR DESCRIPTION
## Summary
This PR adds support for the `diorite` platform (Pebble 2) to the app's target platforms.

## Changes
- Added `"diorite"` to the `targetPlatforms` array in `package.json`

## Motivation
Currently, the app only targets `aplite` and `basalt` platforms, which prevents it from being installed on Pebble 2 devices (diorite platform). This addition enables diorite users to install and use the app from the Rebble appstore.

## Testing
- Verified that the change follows the correct format for Pebble SDK 3 platform targeting
- No code changes required, only configuration update

🤖 Generated with [Claude Code](https://claude.com/claude-code)